### PR TITLE
bump version to 0.2.3 and update dependencies for akshare and cachetools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "akshare-one"
-version = "0.2.2"
+version = "0.2.3"
 description = "Standardized interface for Chinese financial market data, built on AKShare with unified data formats and simplified APIs"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "akshare>=1.16.98",
-    "cachetools>=6.0.0",
+    "akshare>=1.17.5",
+    "cachetools>=6.1.0",
 ]
 license = "MIT"
 keywords = ["akshare", "financial-data", "stock-data", "quant"]
@@ -19,7 +19,7 @@ Repository = "https://github.com/zwldarren/akshare-one.git"
 dev = [
     "pre-commit>=4.2.0",
     "pytest>=8.4.0",
-    "pytest-cov>=6.1.1",
+    "pytest-cov>=6.2.1",
     "ruff>=0.11.13",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "akshare"
-version = "1.17.4"
+version = "1.17.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -104,14 +104,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "xlrd" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/d2/e5f82a52dcea62e24e415a942a8cb45214d18a2439e00a04c7b4f421971e/akshare-1.17.4.tar.gz", hash = "sha256:2a85ca11470b3a9623757222a45978641ddfaa0291bfcfc20e2ec16b0c41910b", size = 838693, upload-time = "2025-06-16T12:37:12.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/54/f97e3bb9f585a01ba56b3b8fc9988f647822b1e2ce821ae7acf132100053/akshare-1.17.5.tar.gz", hash = "sha256:38624ef144b0bca7365ffd3538c2afb2934d1b90a0c38fa5b511871156d7fff9", size = 838887, upload-time = "2025-06-17T08:19:25.796Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/96/b004050e903d462c62359d43716c7fd1e07900fb0e279b9b2feb6ebf1647/akshare-1.17.4-py3-none-any.whl", hash = "sha256:e732911e6e7b0811d04d9d946003325d8de84635db7c7003cd92f2fffb3fd69c", size = 1052874, upload-time = "2025-06-16T12:37:11.622Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/1d/33cebc2b7a34b73e457125e358b99bfa178c796c72f7962f9d2af15abadd/akshare-1.17.5-py3-none-any.whl", hash = "sha256:f3c3e3261ae3074c54363bc0d50a315c78622352938af4dc535353a682215738", size = 1053060, upload-time = "2025-06-17T08:19:24.242Z" },
 ]
 
 [[package]]
 name = "akshare-one"
-version = "0.2.2"
+version = "0.2.3"
 source = { virtual = "." }
 dependencies = [
     { name = "akshare" },
@@ -128,15 +128,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "akshare", specifier = ">=1.16.98" },
-    { name = "cachetools", specifier = ">=6.0.0" },
+    { name = "akshare", specifier = ">=1.17.5" },
+    { name = "cachetools", specifier = ">=6.1.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.0" },
-    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
 
@@ -164,11 +164,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "6.0.0"
+version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/b0/f539a1ddff36644c28a61490056e5bae43bd7386d9f9c69beae2d7e7d6d1/cachetools-6.0.0.tar.gz", hash = "sha256:f225782b84438f828328fc2ad74346522f27e5b1440f4e9fd18b20ebfd1aa2cf", size = 30160, upload-time = "2025-05-23T20:01:13.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/89/817ad5d0411f136c484d535952aef74af9b25e0d99e90cdffbe121e6d628/cachetools-6.1.0.tar.gz", hash = "sha256:b4c4f404392848db3ce7aac34950d17be4d864da4b8b66911008e430bc544587", size = 30714, upload-time = "2025-06-16T18:51:03.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/c3/8bb087c903c95a570015ce84e0c23ae1d79f528c349cbc141b5c4e250293/cachetools-6.0.0-py3-none-any.whl", hash = "sha256:82e73ba88f7b30228b5507dce1a1f878498fc669d972aef2dde4f3a3c24f103e", size = 10964, upload-time = "2025-05-23T20:01:11.323Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f0/2ef431fe4141f5e334759d73e81120492b23b2824336883a91ac04ba710b/cachetools-6.1.0-py3-none-any.whl", hash = "sha256:1c7bb3cf9193deaf3508b7c5f2a79986c13ea38965c5adcff1f84519cf39163e", size = 11189, upload-time = "2025-06-16T18:51:01.514Z" },
 ]
 
 [[package]]
@@ -768,15 +768,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "6.1.1"
+version = "6.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
+    { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857, upload-time = "2025-04-05T14:07:51.592Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841, upload-time = "2025-04-05T14:07:49.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix `get_inner_trade_data` error