### PR TITLE
fix cache bug in get_basic_info

### DIFF
--- a/src/akshare_one/modules/info/eastmoney.py
+++ b/src/akshare_one/modules/info/eastmoney.py
@@ -20,7 +20,7 @@ class EastmoneyInfo(InfoDataProvider):
 
     @cache(
         "info_cache",
-        key=lambda self, symbol=None: f"eastmoney_{symbol}",
+        key=lambda symbol=None: f"eastmoney_{symbol}",
     )
     def get_basic_info(self) -> pd.DataFrame:
         """获取东方财富个股信息"""


### PR DESCRIPTION
The key in cache only accepts one parameter. I believe it's a typo here. 